### PR TITLE
Remove 'malloc.h' include.

### DIFF
--- a/src/tools.c
+++ b/src/tools.c
@@ -59,7 +59,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #else
 #  define SEPARATOR "/"
 #  include <unistd.h>
-#  include <malloc.h>
 #  include <memory.h>
 #endif
 


### PR DESCRIPTION
This header is not POSIX and does not exist on some systems, such
as Mac OS X.
