### PR TITLE
Read MID and MUS files

### DIFF
--- a/src/compose.c
+++ b/src/compose.c
@@ -464,6 +464,10 @@ void CMPOmakePWAD(const char *doomwad,WADTYPE type, const char *PWADname,
 	    { size=WADRwriteLump(&rwad,file);
 	      Detail("CM66", "Reading music file %s", fname (file));
 	    }
+	    else if(MakeFileName(file,DataDir,"MUSICS","",filenam,"MID")==TRUE)
+	    { size=WADRwriteLump(&rwad,file);
+	      Detail("CM66", "Reading music file %s", fname (file));
+	    }
 	    else if(CMPOcopyFromWAD(&size,&rwad,DataDir,"MUSICS",name,
 		  filenam)!=TRUE)
 	      ProgError("CM67", "Can't find music %s",file);

--- a/src/compose.c
+++ b/src/compose.c
@@ -466,11 +466,11 @@ void CMPOmakePWAD(const char *doomwad,WADTYPE type, const char *PWADname,
 	    }
 	    else if(MakeFileName(file,DataDir,"MUSICS","",filenam,"MID")==TRUE)
 	    { size=WADRwriteLump(&rwad,file);
-	      Detail("CM67", "Reading music file %s", fname (file));
+	      Detail("CM68", "Reading music file %s", fname (file));
 	    }
 	    else if(CMPOcopyFromWAD(&size,&rwad,DataDir,"MUSICS",name,
 		  filenam)!=TRUE)
-	      ProgError("CM68", "Can't find music %s",file);
+	      ProgError("CM67", "Can't find music %s",file);
 	  }
 	  WADRdirAddEntry(&rwad,start,size,name);
 	}

--- a/src/compose.c
+++ b/src/compose.c
@@ -466,11 +466,11 @@ void CMPOmakePWAD(const char *doomwad,WADTYPE type, const char *PWADname,
 	    }
 	    else if(MakeFileName(file,DataDir,"MUSICS","",filenam,"MID")==TRUE)
 	    { size=WADRwriteLump(&rwad,file);
-	      Detail("CM66", "Reading music file %s", fname (file));
+	      Detail("CM67", "Reading music file %s", fname (file));
 	    }
 	    else if(CMPOcopyFromWAD(&size,&rwad,DataDir,"MUSICS",name,
 		  filenam)!=TRUE)
-	      ProgError("CM67", "Can't find music %s",file);
+	      ProgError("CM68", "Can't find music %s",file);
 	  }
 	  WADRdirAddEntry(&rwad,start,size,name);
 	}


### PR DESCRIPTION
This should allow Deutex to recognise both MID and MUS files.
Hence, renaming MID files to MUS won't be necessary. This is only
for the building process, it will still export all music lumps in a WAD
with MUS extension. 
I wasn't sure if I should change the "CM 66" to another number, 
since both if statements are essentially the same, so I just kept it
as CM 66.