### PR TITLE
Remove case TGA

### DIFF
--- a/src/extract.c
+++ b/src/extract.c
@@ -56,7 +56,6 @@ static bool XTRbmpSave(int16_t *pinsrX,int16_t *pinsrY,struct WADDIR  *entry,
    { case PICGIF: extens="GIF";break;
      case PICBMP: extens="BMP";break;
      case PICPPM: extens="PPM";break;
-     case PICTGA: extens="TGA";break;
      default: Bug("EX47", "Invalid img type %d", (int) Picture);
    }
    res = MakeFileName(file,DataDir,dir,"",name,extens);


### PR DESCRIPTION
I don't think there is any TGA support. There certainly is no -tga parameter, 
nor did I find any results for "TGA" in picture.c and picture.h