### PR TITLE
Increase WAD filename recognition size

### DIFF
--- a/src/tools.c
+++ b/src/tools.c
@@ -263,7 +263,7 @@ bool MakeFileName(char file[128], const char *path, const char *dir, const
 /*
 ** Get the root name of a WAD file
 */
-void GetNameOfWAD(char name[8], const char *path)
+void GetNameOfWAD(char name[32], const char *path)
 { int16_t n, nam,len;
   len=(int16_t)strlen(path);
   /*find end of DOS or Unix path*/
@@ -278,7 +278,7 @@ void GetNameOfWAD(char name[8], const char *path)
     }
   /*find root name*/
   /* FIXME AYM 1999-06-09: Do we really have to truncate to 8 ? */
-  for (n = 0; n < 8; n++) {
+  for (n = 0; n < 32; n++) {
       switch (path[nam + n]) {
       case '.':
       case '\0':

--- a/src/tools.h
+++ b/src/tools.h
@@ -67,7 +67,7 @@ void MakeDir(char file[128], const char *path, const char *dir, const char
     *sdir);
 bool MakeFileName(char file[128], const char *path, const char *dir, const
     char *sdir, const char *name, const char *extens);
-void GetNameOfWAD(char name[8], const char *path);
+void GetNameOfWAD(char name[32], const char *path);
 int16_t Chsize(int handle,int32_t newsize);
 int32_t Get_File_Time(const char *path);
 void Set_File_Time(const char *path, int32_t time);

--- a/src/wadio.c
+++ b/src/wadio.c
@@ -73,11 +73,11 @@ void set_input_wad_endianness (int big_endian)
  *
  *	Return 0 on success, non-zero on failure.
  */
-int wad_read_name (FILE *fd, char name[8])
+int wad_read_name (FILE *fd, char name[32])
 {
   size_t n;
   int end = 0;
-  for (n = 0; n < 8; n++)
+  for (n = 0; n < 32; n++)
   {
     int c = getc (fd);
     name[n] = end ? '\0' : toupper (c);
@@ -90,9 +90,9 @@ int wad_read_name (FILE *fd, char name[8])
 int wad_write_name (FILE *fd, const char *name)
 {
   size_t n;
-  for (n = 0; n < 8 && name[n]; n++)
+  for (n = 0; n < 32 && name[n]; n++)
     putc (toupper (name[n]), fd);
-  for (; n < 8; n++)
+  for (; n < 32; n++)
     putc ('\0', fd);
   return ferror (fd);
 }

--- a/src/wadio.h
+++ b/src/wadio.h
@@ -11,5 +11,5 @@ extern int (* wad_write_i16) (FILE *, int16_t);
 extern int (* wad_write_i32) (FILE *, int32_t);
 extern int (* wad_read_i16)  (FILE *, int16_t *);
 extern int (* wad_read_i32)  (FILE *, int32_t *);
-int wad_read_name (FILE *fd, char name[8]);
+int wad_read_name (FILE *fd, char name[32]);
 int wad_write_name (FILE *fd, const char *name);


### PR DESCRIPTION
Set to 32 characters instead of 8 characters. Hopefully, this should allow reading WADs without having to conform to the 8 character limit.