### PR TITLE
Silence warn_unused_result

### DIFF
--- a/src/sound.c
+++ b/src/sound.c
@@ -111,11 +111,11 @@ char *SNDloadWaveFile(char *file, int32_t * psize, int32_t * pspeed)
         chunk += sizeof(struct CHUNK) + peek_i32_le(&headc.size);
     }
     fseek(fp, chunk, SEEK_SET);
-   if(fread(&headf, sizeof(struct WAVEFMT), 1, fp) == 1) {
-     Info("RR01", "%s is a WAVE file", fname(file));
-   } else {
-     ProgError("RR02", "%s is not a WAVE file", fname(file));
-   }
+    if (fread(&headf, sizeof(struct WAVEFMT), 1, fp) == 1) {
+        Info("RR01", "%s is a WAVE file", fname(file));
+    } else {
+        ProgError("RR02", "%s is not a WAVE file", fname(file));
+    }
     if (peek_i16_le(&headf.tag) != 1)
         ProgError("RR16", "%s: not raw data", fname(file));
     if (peek_i16_le(&headf.channel) != 1)

--- a/src/sound.c
+++ b/src/sound.c
@@ -111,7 +111,11 @@ char *SNDloadWaveFile(char *file, int32_t * psize, int32_t * pspeed)
         chunk += sizeof(struct CHUNK) + peek_i32_le(&headc.size);
     }
     fseek(fp, chunk, SEEK_SET);
-    fread(&headf, sizeof(struct WAVEFMT), 1, fp);
+   if(fread(&headf, sizeof(struct WAVEFMT), 1, fp) == 1) {
+     Info("RR01", "%s is a WAVE file", fname(file));
+   } else {
+     ProgError("RR02", "%s is not a WAVE file", fname(file));
+   }
     if (peek_i16_le(&headf.tag) != 1)
         ProgError("RR16", "%s: not raw data", fname(file));
     if (peek_i16_le(&headf.channel) != 1)


### PR DESCRIPTION
`sound.c: In function ‘SNDloadWaveFile’: sound.c:114:10: warning: ignoring return value of ‘fread’, declared with attribute warn_unused_result [-Wunused-result]`