### PR TITLE
increase array size for char "tname" variable

### DIFF
--- a/src/texture.c
+++ b/src/texture.c
@@ -393,7 +393,7 @@ void TXUreadTEXTURE(const char *texture1_name, const char *Data,
     int16_t Xofs, Yofs, Pindex; /* x,y coordinate in texture space */
     /* patch name index in PNAMES table */
     int32_t MaxPindex;
-    static char tname[8];       /*texture name */
+    static char tname[10];       /*texture name */
     static char pname[8];       /*patch name */
     size_t header_size = 0;
     size_t item_size = 0;


### PR DESCRIPTION
In src/texture.c:466 the "t" variable is of type signed short, so the
theoretically lowest possible value is -32768, which takes 6 digits.
The "TEX" string literal takes another 3 digits, so together with the
'\0' string delimiter byte we need an array size of 10 bytes for the
"tname" variable to be able to store the full maximum length string.