### PR TITLE
build: properly use pkgconfig variables

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,5 +6,5 @@ mkwad.h png_tools.c png_tools.h picture.c picture.h sound.c sound.h	\
 sscript.c sscript.h text.c text.h texture.c texture.h tools.c tools.h	\
 usedidx.c usedidx.h wadio.c wadio.h
 
-deutex_LDADD=@PNG_LIBS@
-AM_CFLAGS=@PNG_CFLAGS@
+deutex_LDADD = ${PNG_LIBS}
+AM_CPPFLAGS = ${PNG_CFLAGS}


### PR DESCRIPTION
pkgconfig's cflags really are CPPFLAGS; and ${} should be used so it can be overriden at make time.