### PR TITLE
Support textures in TX_START..TX_END markers

### DIFF
--- a/src/compose.c
+++ b/src/compose.c
@@ -96,22 +96,23 @@ static int16_t CMPOloadPic(int32_t * size, struct WADINFO *rwad,
 /*
 ** find a raw picture, for TX_START support.
 */
-static void CMPOloadRawPic(int32_t * size, struct WADINFO *rwad,
+static bool CMPOloadRawPic(int32_t * size, struct WADINFO *rwad,
                            char *file, const char *DataDir,
                            const char *Dir, const char *nam,
                            const char *filenam)
 {
-    if (MakeFileName(file, DataDir, Dir, "", filenam, "gif") ||
-        MakeFileName(file, DataDir, Dir, "", filenam, "jpeg") ||
+    /* most ports support PNG, ZDoom also supports JPEG */
+    if (MakeFileName(file, DataDir, Dir, "", filenam, "jpeg") ||
         MakeFileName(file, DataDir, Dir, "", filenam, "jpg") ||
         MakeFileName(file, DataDir, Dir, "", filenam, "png")) {
 
         *size = WADRwriteLump(rwad, file);
-        return;
+        return true;
     }
 
     /* file has the last filename tried, i.e. NAME.png */
     Warning("PC91", "could not find file %s, .gif, or .jpeg", file);
+    return false;
 }
 
 struct WADINFO *CMPOrwad;
@@ -430,6 +431,7 @@ void CMPOmakePWAD(const char *doomwad, WADTYPE type, const char *PWADname,
 
                 WADRalign4(&rwad);  /*align entry on int32_t word */
                 start = WADRposition(&rwad);
+                size = 0;
 
                 /* when X value is > 0, insert as a raw lump (no conversion) */
                 if (X > 0) {

--- a/src/deutex.h
+++ b/src/deutex.h
@@ -80,9 +80,8 @@ typedef int16_t IMGTYPE;
 #define PICGIF          (2)
 #define PICPPM          (3)
 #define PICWAD          (5)
-#ifdef HAVE_LIBPNG
 #define PICPNG          (6)
-#endif
+#define PICJPEG         (7)
 
 /*wad directory*/
 struct WADDIR {                 /*same as in doom */
@@ -139,6 +138,7 @@ typedef int16_t ENTRY;
 #define EMUSIC          0x0B00
 #define   EMUS          0x0B01
 #define   EMIDI         0x0B02
+#define ETXSTART        0x0C00
 #define EDATA           0x1000
 #define ESNEA           0x2000
 #define   ESNEAP        0x2001  /* Snea using PLAYPAL */

--- a/src/ident.c
+++ b/src/ident.c
@@ -533,6 +533,48 @@ static void IDENTdirPatches(ENTRY * ids, struct WADINFO *info, char *Pnam,
 }
 
 /*
+** identifies graphics between TX_START and TX_END
+**
+** Precond: ids contains EZZZZ for unidentified entries
+*/
+static void IDENTdirTXSTART(ENTRY * ids, struct WADINFO *info)
+{
+    int16_t tx_start;
+    int16_t tx_end;
+    int16_t n;
+
+    ident_func = "IDENTdirTXSTART";
+    /*
+    ** check if there are TX_START textures
+    */
+    tx_start = WADRfindEntry(info, "TX_START");
+    tx_end = WADRfindEntry(info, "TX_END");
+
+    if (tx_start < 0 || tx_end < 0) {
+        if (tx_start >= 0)
+            Warning("ITX1", "TX_START exists without matching TX_END");
+        else if (tx_end >= 0)
+            Warning("ITX2", "TX_END exists without matching TX_START");
+        return;
+    }
+    if (tx_end < tx_start) {
+        Warning("ITX3", "TX_START and TX_END occur in wrong order");
+        return;
+    }
+
+    /*
+    ** declare TX_START textures
+    */
+    IDENTsetType(ids, info, tx_start, EVOID);
+    IDENTsetType(ids, info, tx_end, EVOID);
+
+    for (n = tx_end - 1; n > tx_start; n--) {
+        /* format is determined later, when extracting it */
+        IDENTsetType(ids, info, n, ETXSTART);
+    }
+}
+
+/*
 ** Ident unreferenced graphics
 */
 static void IDENTdirGraphics(ENTRY * ids, struct WADINFO *info)
@@ -803,6 +845,7 @@ ENTRY *IDENTentriesIWAD(struct WADINFO *info, char *Pnam, int32_t Pnamsz,
     */
     for (n = 0; n < info->ntry; n++)
         ids[n] = EZZZZ;
+    IDENTdirTXSTART(ids, info); /* fast */
     IDENTdirSprites(ids, info, false);  /*fast */
     IDENTdirFlats(ids, info);   /*fast */
     IDENTdirLevels(ids, info);  /*fast */
@@ -848,6 +891,7 @@ ENTRY *IDENTentriesPWAD(struct WADINFO * info, char *Pnam, int32_t Pnamsz)
     */
     for (n = 0; n < info->ntry; n++)
         ids[n] = EZZZZ;
+    IDENTdirTXSTART(ids, info);
     IDENTdirSprites(ids, info, true);
     IDENTdirFlats(ids, info);
     IDENTdirLevels(ids, info);

--- a/src/tools.c
+++ b/src/tools.c
@@ -179,7 +179,7 @@ bool MakeFileName(char file[128], const char *path, const char *dir, const
     char name2[8]; /* AYM 1999-01-13: keep checker happy */
     /* deal with VILE strange name
     ** replace the VILE\
-    ** by          VIL^B
+    ** by          VILE^
     */
     Normalise(name2, name);
 


### PR DESCRIPTION
These two commits add support for textures within the TX_START and TX_END
markers.  Both composing wads and extracting wads are handled.

It normally converts textures to/from the DOOM patch format, but using a positive
integer after the texture name in the wadinfo.txt file causes a PNG or JPEG file
to be stored directly in the wad (i.e. no conversion is done).  When extracting, the
first few bytes of a lump are inspected to determine if the lump is a PNG or JPEG
image.
