### PR TITLE
Updated entry parser to support a "/raw" flag.

### DIFF
--- a/src/compose.c
+++ b/src/compose.c
@@ -140,6 +140,7 @@ void CMPOmakePWAD(const char *doomwad, WADTYPE type, const char *PWADname,
     bool NeedPNAME = false;
     bool FoundOne = false;
     bool Repeat;
+    FLAGS Flags;
     IMGTYPE Picture;
     /*optional insertion point */
     int16_t X, Y;
@@ -177,8 +178,8 @@ void CMPOmakePWAD(const char *doomwad, WADTYPE type, const char *PWADname,
     */
     if (select & BLEVEL) {
         if (TXTseekSection(TXT, "LEVELS")) {
-            while (TXTentryParse
-                   (name, filenam, &X, &Y, &Repeat, TXT, false)) {
+            while (TXTparseEntry
+                   (name, filenam, &X, &Y, &Flags, &Repeat, TXT, false)) {
                 p = IDENTlevel(name);
                 if (p < 0)
                     ProgError("CM11", "Illegal level name %s",
@@ -204,8 +205,8 @@ void CMPOmakePWAD(const char *doomwad, WADTYPE type, const char *PWADname,
         const char *playpal_lumpname = NULL;
 
         if (TXTseekSection(TXT, "LUMPS")) {
-            while (TXTentryParse
-                   (name, filenam, &X, &Y, &Repeat, TXT, false)) {
+            while (TXTparseEntry
+                   (name, filenam, &X, &Y, &Flags, &Repeat, TXT, false)) {
                 if (strcmp(name, "PLAYPAL") == 0) {
                     FILE *playpal_fp;
 
@@ -250,8 +251,8 @@ void CMPOmakePWAD(const char *doomwad, WADTYPE type, const char *PWADname,
         start = size = 0;
         if (TXTseekSection(TXT, "LUMPS")) {
             Phase("CM30", "Making lumps");
-            while (TXTentryParse
-                   (name, filenam, &X, &Y, &Repeat, TXT, false)) {
+            while (TXTparseEntry
+                   (name, filenam, &X, &Y, &Flags, &Repeat, TXT, false)) {
                 if (!Repeat) {
                     WADRalign4(&rwad);  /*align entry on int32_t word */
                     start = WADRposition(&rwad);
@@ -304,8 +305,8 @@ void CMPOmakePWAD(const char *doomwad, WADTYPE type, const char *PWADname,
                 Warning("CM51", "Can't find TEXTURE1 in main WAD");
             FoundOne = false;
             /*read TEXTURES composing TEXTURE1 */
-            while (TXTentryParse
-                   (name, filenam, &X, &Y, &Repeat, TXT, false)) {
+            while (TXTparseEntry
+                   (name, filenam, &X, &Y, &Flags, &Repeat, TXT, false)) {
                 if (MakeFileName
                     (file, DataDir, "TEXTURES", "", filenam, "TXT")) {
                     Detail("CM52", "Reading texture file %s", fname(file));
@@ -356,8 +357,8 @@ void CMPOmakePWAD(const char *doomwad, WADTYPE type, const char *PWADname,
                 Warning("CM56", "Can't find TEXTURE2 in main WAD");
             FoundOne = false;
             /*read TEXTURES composing TEXTURE2 */
-            while (TXTentryParse
-                   (name, filenam, &X, &Y, &Repeat, TXT, false)) {
+            while (TXTparseEntry
+                   (name, filenam, &X, &Y, &Flags, &Repeat, TXT, false)) {
                 if (MakeFileName
                     (file, DataDir, "TEXTURES", "", filenam, "TXT")) {
                     Detail("CM57", "Reading texture file %s", fname(file));
@@ -415,8 +416,8 @@ void CMPOmakePWAD(const char *doomwad, WADTYPE type, const char *PWADname,
         if (TXTseekSection(TXT, "TX_START")) {
             Phase("CM59", "Making TX_START textures");
             FoundOne = false;
-            while (TXTentryParse
-                   (name, filenam, &X, &Y, &Repeat, TXT, true)) {
+            while (TXTparseEntry
+                   (name, filenam, &X, &Y, &Flags, &Repeat, TXT, false)) {
                 /* only add markers if we have some textures */
                 if (!FoundOne) {
                     WADRalign4(&rwad);  /*align entry on int32_t word */
@@ -429,8 +430,8 @@ void CMPOmakePWAD(const char *doomwad, WADTYPE type, const char *PWADname,
                 start = WADRposition(&rwad);
                 size = 0;
 
-                /* when X value is > 0, insert as a raw lump (no conversion) */
-                if (X > 0) {
+                /* when marked "raw", insert as a raw lump (no conversion) */
+                if (Flags & F_RAW) {
                     CMPOloadRawPic(&size, &rwad, file, DataDir, "TX_START",
                                    name, filenam);
                 } else {
@@ -454,8 +455,8 @@ void CMPOmakePWAD(const char *doomwad, WADTYPE type, const char *PWADname,
         start = size = 0;
         if (TXTseekSection(TXT, "SOUNDS")) {
             Phase("CM60", "Making sounds");
-            while (TXTentryParse
-                   (name, filenam, &X, &Y, &Repeat, TXT, false)) {
+            while (TXTparseEntry
+                   (name, filenam, &X, &Y, &Flags, &Repeat, TXT, false)) {
                 if (!Repeat) {
                     WADRalign4(&rwad);  /*align entry on int32_t word */
                     start = WADRposition(&rwad);
@@ -493,8 +494,8 @@ void CMPOmakePWAD(const char *doomwad, WADTYPE type, const char *PWADname,
         start = size = 0;
         if (TXTseekSection(TXT, "MUSICS")) {
             Phase("CM65", "Making musics");
-            while (TXTentryParse
-                   (name, filenam, &X, &Y, &Repeat, TXT, false)) {
+            while (TXTparseEntry
+                   (name, filenam, &X, &Y, &Flags, &Repeat, TXT, false)) {
                 if (!Repeat) {
                     WADRalign4(&rwad);  /*align entry on int32_t word */
                     start = WADRposition(&rwad);
@@ -527,8 +528,8 @@ void CMPOmakePWAD(const char *doomwad, WADTYPE type, const char *PWADname,
         start = size = 0;
         if (TXTseekSection(TXT, "GRAPHICS")) {
             Phase("CM70", "Making graphics");
-            while (TXTentryParse
-                   (name, filenam, &X, &Y, &Repeat, TXT, true)) {
+            while (TXTparseEntry
+                   (name, filenam, &X, &Y, &Flags, &Repeat, TXT, true)) {
                 if (!Repeat) {
                     WADRalign4(&rwad);  /*align entry on int32_t word */
                     start = WADRposition(&rwad);
@@ -551,8 +552,8 @@ void CMPOmakePWAD(const char *doomwad, WADTYPE type, const char *PWADname,
         if (TXTseekSection(TXT, "SPRITES")) {
             Phase("CM75", "Making sprites");
             FoundOne = false;
-            while (TXTentryParse
-                   (name, filenam, &X, &Y, &Repeat, TXT, true)) {
+            while (TXTparseEntry
+                   (name, filenam, &X, &Y, &Flags, &Repeat, TXT, true)) {
                 /* first sprite seen? */
                 if (!Repeat || !FoundOne) {
                     WADRalign4(&rwad);  /*align entry on int32_t word */
@@ -595,8 +596,8 @@ void CMPOmakePWAD(const char *doomwad, WADTYPE type, const char *PWADname,
         start = size = 0;
         if (TXTseekSection(TXT, "PATCHES")) {
             Phase("CM80", "Making patches");
-            while (TXTentryParse
-                   (name, filenam, &X, &Y, &Repeat, TXT, true)) {
+            while (TXTparseEntry
+                   (name, filenam, &X, &Y, &Flags, &Repeat, TXT, true)) {
                 if (!Repeat || !FoundOne) {
                     WADRalign4(&rwad);  /*align entry on int32_t word */
                     start = WADRposition(&rwad);
@@ -683,8 +684,8 @@ void CMPOmakePWAD(const char *doomwad, WADTYPE type, const char *PWADname,
         if (TXTseekSection(TXT, "FLATS")) {
             Phase("CM85", "Making flats");
             FoundOne = false;
-            while (TXTentryParse
-                   (name, filenam, &X, &Y, &Repeat, TXT, false)) {
+            while (TXTparseEntry
+                   (name, filenam, &X, &Y, &Flags, &Repeat, TXT, false)) {
                 if (!Repeat || !FoundOne) {
                     /*align entry on int32_t word */
                     WADRalign4(&rwad);

--- a/src/extract.c
+++ b/src/extract.c
@@ -324,7 +324,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                         WADRclose(&lwad);
                     }
                     TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                INVALIDINT, false, false);
+                                INVALIDINT, 0, false, false);
                     p = pmax - 1;
                 }
             }
@@ -350,7 +350,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                 if ((ostart == pwad.dir[p].start)
                     && (osize == pwad.dir[p].size)) {
                     TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                INVALIDINT, true, false);
+                                INVALIDINT, 0, true, false);
                 } else {
                     ostart = pwad.dir[p].start;
                     osize = pwad.dir[p].size;
@@ -377,7 +377,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                         }
                     }
                     TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                INVALIDINT, false, false);
+                                INVALIDINT, 0, false, false);
                 }
             }
         }
@@ -406,7 +406,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                     else
                         name = pdir[p].name;
                     TXTaddEntry(TXT, name, NULL, INVALIDINT, INVALIDINT,
-                                false, false);
+                                0, false, false);
                     res =
                         MakeFileName(file, DataDir, "TEXTURES", "", name,
                                      "TXT");
@@ -436,7 +436,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                 TXTaddComment(TXT, "List of definitions for TEXTURE2");
                 TXTaddSection(TXT, "texture2");
                 TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                            INVALIDINT, false, false);
+                            INVALIDINT, 0, false, false);
                 res =
                     MakeFileName(file, DataDir, "TEXTURES", "",
                                  pdir[p].name, "TXT");
@@ -490,7 +490,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                                     lump_name(pwad.dir[p].name));
                     } else {
                         TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                    INVALIDINT, false, false);
+                                    INVALIDINT, 0, false, false);
                     }
                 } else {
                     /* write PNG or JPEG as a raw file, no conversion */
@@ -507,7 +507,8 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                         Detail("EX74", "Saved lump as   %s", fname(file));
                     }
 
-                    TXTaddEntry(TXT, pdir[p].name, NULL, 1, 0, false, true);
+                    TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
+                                INVALIDINT, F_RAW, false, false);
                 }
             }
         }
@@ -532,7 +533,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                 if ((ostart == pwad.dir[p].start)
                     && (osize == pwad.dir[p].size)) {
                     TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                INVALIDINT, true, false);
+                                INVALIDINT, 0, true, false);
                 } else {
                     ostart = pwad.dir[p].start;
                     osize = pwad.dir[p].size;
@@ -558,7 +559,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                                    fname(file));
                         }
                         TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                    INVALIDINT, false, false);
+                                    INVALIDINT, 0, false, false);
                         break;
                     case ESNDWAV:
                         switch (Sound) {
@@ -586,7 +587,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                             free(buffer);
                         }
                         TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                    INVALIDINT, false, false);
+                                    INVALIDINT, 0, false, false);
                         break;
                     default:
                         Bug("EX31", "Invalid snd type %d", piden[p]);
@@ -615,7 +616,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                 if ((ostart == pwad.dir[p].start)
                     && (osize == pwad.dir[p].size)) {
                     TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                INVALIDINT, true, false);
+                                INVALIDINT, 0, true, false);
                 } else {
                     ostart = pwad.dir[p].start;
                     osize = pwad.dir[p].size;
@@ -634,7 +635,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                         WADRsaveEntry(&pwad, p, file);
                     }
                     TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                INVALIDINT, false, false);
+                                INVALIDINT, 0, false, false);
                 }
             }
         }
@@ -655,7 +656,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                 if ((ostart == pwad.dir[p].start)
                     && (osize == pwad.dir[p].size)) {
                     TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                INVALIDINT, true, false);
+                                INVALIDINT, 0, true, false);
                 } else {
                     ostart = pwad.dir[p].start;
                     osize = pwad.dir[p].size;
@@ -670,7 +671,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                             EntryFound = true;
                         }
                         TXTaddEntry(TXT, pdir[p].name, NULL, insrX, insrY,
-                                    false, true);
+                                    0, false, true);
                     } else if (XTRbmpSave
                                (&insrX, &insrY, &pdir[p], PFLAT,
                                 DataDir, "LUMPS", &pwad, Picture,
@@ -725,7 +726,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                 if ((ostart == pwad.dir[p].start)
                     && (osize == pwad.dir[p].size)) {
                     TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                INVALIDINT, true, false);
+                                INVALIDINT, 0, true, false);
                 } else {
                     ostart = pwad.dir[p].start;
                     osize = pwad.dir[p].size;
@@ -737,7 +738,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                                 lump_name(pwad.dir[p].name));
                     } else {
                         TXTaddEntry(TXT, pdir[p].name, NULL, insrX, insrY,
-                                    false, true);
+                                    0, false, true);
                     }
                 }
             }
@@ -763,7 +764,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                     (&insrX, &insrY, &pdir[p], PPATCH, DataDir, "PATCHES",
                      &pwad, Picture, WSafe, cusage)) {
                     TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                INVALIDINT, false, false);
+                                INVALIDINT, 0, false, false);
                 } else {
                     Warning("EX46", "Failed to write patch %s",
                             lump_name(pwad.dir[p].name));
@@ -797,7 +798,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                 if ((ostart == pwad.dir[p].start)
                     && (osize == pwad.dir[p].size)) {
                     TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                INVALIDINT, true, false);
+                                INVALIDINT, 0, true, false);
                 } else {
                     ostart = pwad.dir[p].start;
                     osize = pwad.dir[p].size;
@@ -809,7 +810,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                                     lump_name(pwad.dir[p].name));
                     } else
                         TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                    INVALIDINT, false, false);
+                                    INVALIDINT, 0, false, false);
                 }
             }
         }
@@ -838,7 +839,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                 if ((ostart == pwad.dir[p].start)
                     && (osize == pwad.dir[p].size)) {
                     TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                INVALIDINT, true, false);
+                                INVALIDINT, 0, true, false);
                 } else {
                     ostart = pwad.dir[p].start;
                     osize = pwad.dir[p].size;
@@ -852,7 +853,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                                 lump_name(pwad.dir[p].name));
                     } else {
                         TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                    INVALIDINT, false, false);
+                                    INVALIDINT, 0, false, false);
                     }
                 }
             }
@@ -882,7 +883,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                 if ((ostart == pwad.dir[p].start)
                     && (osize == pwad.dir[p].size)) {
                     TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                INVALIDINT, true, false);
+                                INVALIDINT, 0, true, false);
                 } else {
                     ostart = pwad.dir[p].start;
                     osize = pwad.dir[p].size;
@@ -896,7 +897,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                                 lump_name(pwad.dir[p].name));
                     } else {
                         TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                    INVALIDINT, false, false);
+                                    INVALIDINT, 0, false, false);
                     }
                 }
             }
@@ -926,7 +927,7 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                 if ((ostart == pwad.dir[p].start)
                     && (osize == pwad.dir[p].size)) {
                     TXTaddEntry(TXT, pdir[p].name, NULL, INVALIDINT,
-                                INVALIDINT, true, false);
+                                INVALIDINT, 0, true, false);
                 } else {
                     ostart = pwad.dir[p].start;
                     osize = pwad.dir[p].size;
@@ -945,8 +946,8 @@ void XTRextractWAD(const char *doomwad, const char *DataDir, const char
                                         lump_name(pwad.dir[p].name));
                             } else {
                                 TXTaddEntry(TXT, pdir[p].name, NULL,
-                                            INVALIDINT, INVALIDINT, false,
-                                            false);
+                                            INVALIDINT, INVALIDINT, 0,
+                                            false, false);
                             }
                         }
                     }

--- a/src/text.h
+++ b/src/text.h
@@ -27,6 +27,9 @@ struct TXTFILE {
    supported by the input functions ! */
 extern struct TXTFILE TXTdummy;
 
+typedef uint16_t FLAGS;
+#define F_RAW    0x0001  /* insert/extract with no conversion */
+
 /*
 ** For any Reading of TEXT files
 */
@@ -38,8 +41,8 @@ void TXTcloseR(struct TXTFILE *TXT);
 */
 bool TXTskipComment(struct TXTFILE *TXT);
 bool TXTseekSection(struct TXTFILE *TXT, const char *def);
-bool TXTentryParse(char *name, char *filenam, int16_t * x, int16_t * y,
-                   bool * repeat, struct TXTFILE *TXT, bool XY);
+bool TXTparseEntry(char *name, char *filenam, int16_t * x, int16_t * y,
+                   FLAGS *flags, bool *repeat, struct TXTFILE *TXT, bool XY);
 /*
 ** To read textures
 */
@@ -62,6 +65,7 @@ void TXTcloseW(struct TXTFILE *TXT);
 */
 void TXTaddSection(struct TXTFILE *TXT, const char *def);
 void TXTaddEntry(struct TXTFILE *TXT, const char *name, const char
-                 *filenam, int16_t x, int16_t y, bool repeat, bool XY);
+                 *filenam, int16_t x, int16_t y, FLAGS flags,
+                 bool repeat, bool XY);
 void TXTaddComment(struct TXTFILE *TXT, const char *text);
 void TXTaddEmptyLine(struct TXTFILE *TXT);


### PR DESCRIPTION
This flag generally must appear after the entry name, but may also appear after the "= filename" syntax (for consistency with XY offsets which can appear in either place).

The beginning slash is part of the flag, and the parser could easily be extended to recognise new flags, which may be useful in the future.

Main use for this "/raw" flag is with the [TX_START] section, where it causes images to be inserted directly into the wad (the flag replaces the previously hacky method of using the XY offsets to mark such images).  This "/raw" flag may have more uses in the future.

I also renamed TXTentryParse --> TXTparseEntry, consistent with the "verb + Noun" format of most other function names. Plus I improved the way the "= filename" syntax was parsed.

P.S. I tested these changes on a TX_START test wad, and also on FreeDoom.