### PR TITLE
Quick fix to Hexen transparent color handling

### DIFF
--- a/src/color.c
+++ b/src/color.c
@@ -187,6 +187,7 @@ void COLinit(uint8_t invR, uint8_t invG, uint8_t invB, char *Colors,
     } else if (COLpal[33].R == 29 && COLpal[33].G == 32
                && COLpal[33].B == 29 && COLpal[255].R == 255
                && COLpal[255].G == 255 && COLpal[255].B == 255) {
+        i = 0xff;
         name = "Hexen";
     } else if (COLpal[0].R == 0 && COLpal[0].G == 0 && COLpal[0].B == 0
                && COLpal[240].R == 0 && COLpal[240].G == 0


### PR DESCRIPTION
Fixed a small omission that caused a bunch of Hexen graphics to extract with incorrectly transparent areas.

Technically, the problem is symptomatic of handling Doom patch/sprite format as if it has a defined transparent color (it ought to be able to use all 256 colors) but there's ample evidence that id Software's own tools sacrificed a palette entry to transparency also.  The quick fix while not "ideal" is better than before and sufficient for my need.  Fixing it "properly" would require more of an overhaul of the program's patch handling.

In fact, the Hexen IWAD's COLORMAP treats color 255 strangely, anyway.  Extracting the IWAD ripper ball sprites (RIPP*) with this fix will result in erroneous black pixels but that's also what the COLORMAP does to them.  FINALE2 also has an area of this color that ought to appear normally in game as it's not colormapped.  As far as I know these are the only entries that have issues with the fix.

Treating color 0 as transparent might have been assumed due to the layered sky feature using it that way, but this should probably be considered a special case rather than one that extracts as transparency.